### PR TITLE
Booleans are static singletons

### DIFF
--- a/src/gitem.cpp
+++ b/src/gitem.cpp
@@ -89,8 +89,8 @@ namespace GDRIVE {
     }while(0)
 
 #define BOOL_TO_JSON(name) do {\
-    if (name) obj->put(#name, new JTrue());\
-    else obj->put(#name, new JFalse());\
+    if (name) obj->put(#name, JTrue::getInstance());\
+    else obj->put(#name, JFalse::getInstance());\
     }while(0)
 
 #define STRING_TO_JSON(name) do {\


### PR DESCRIPTION
This fixes issue #1 

Evidently, the JTrue and JFalse objects were changed to singletons, and libgdrive was not updated. This PR uses the singleton version.

NOTE: Another option may be to use git subprojects and tie libgdrive to specific commits of those subprojects.
NOTE: I have not tested this fix beyond getting the compile to finish without errors.